### PR TITLE
[3822682274] Fix for draco checkbox when cancelling install 

### DIFF
--- a/Editor/AvatarConfigEditor.cs
+++ b/Editor/AvatarConfigEditor.cs
@@ -24,12 +24,19 @@ namespace ReadyPlayerMe.AvatarLoader.Core
             DrawDefaultInspector();
             DrawMorphTargets();
 
-            if (previousValue != userDracoCompressionField.boolValue && userDracoCompressionField.boolValue)
+            if (!previousValue && userDracoCompressionField.boolValue)
             {
-                if (ModuleInstaller.IsModuleInstalled(ModuleList.DracoCompression.name)) return;
-                if (EditorUtility.DisplayDialog(DIALOG_TITLE, DIALOG_MESSAGE, DIALOG_OK, DIALOG_CANCEL))
+                if (!ModuleInstaller.IsModuleInstalled(ModuleList.DracoCompression.name))
                 {
-                    ModuleInstaller.AddModuleRequest(ModuleList.DracoCompression.Identifier);
+                    if (EditorUtility.DisplayDialog(DIALOG_TITLE, DIALOG_MESSAGE, DIALOG_OK, DIALOG_CANCEL))
+                    {
+                        ModuleInstaller.AddModuleRequest(ModuleList.DracoCompression.Identifier);
+                    }
+                    else
+                    {
+                        userDracoCompressionField.boolValue = false;
+                        serializedObject.ApplyModifiedProperties();
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [3822682274](https://ready-player-me.monday.com/boards/2563815861/pulses/3822682274)

## Description

-   When Draco checkbox is first selected user is asked if they want to import draco package, however upon clicking Cancel or Close button that field stays checked. This PR fixes that issue. 

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Removed

-   draco checkbox only becomes ticked after/if the package is imported

<!-- Testability -->

## How to Test

-   you can test by opening a Unity project and importing the package from this URL https://github.com/readyplayerme/rpm-unity-sdk-core.git#feature/draco-checkbox-fix
- then create an avatarconfig and toggle the use draco compression checkbox and hit cancel. 

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



