### PR TITLE
Offline Avatar Loading

### DIFF
--- a/Runtime/Operations/AvatarDownloader.cs
+++ b/Runtime/Operations/AvatarDownloader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using ReadyPlayerMe.Core;
+using UnityEngine;
 
 namespace ReadyPlayerMe.AvatarLoader
 {
@@ -52,7 +53,8 @@ namespace ReadyPlayerMe.AvatarLoader
                 throw new InvalidDataException($"Expected cast {typeof(string)} instead got ");
             }
 
-            if (!context.Metadata.IsUpdated && File.Exists(context.AvatarUri.LocalModelPath))
+            if ((!context.Metadata.IsUpdated || Application.internetReachability == NetworkReachability.NotReachable)
+                    && File.Exists(context.AvatarUri.LocalModelPath))
             {
                 SDKLogger.Log(TAG, "Loading model from cache.");
                 context.Bytes = File.ReadAllBytes(context.AvatarUri.LocalModelPath);

--- a/Runtime/Operations/MetadataDownloader.cs
+++ b/Runtime/Operations/MetadataDownloader.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using ReadyPlayerMe.AvatarLoader;
 using ReadyPlayerMe.Core;
+using UnityEngine;
 
 namespace ReadyPlayerMe.Loader
 {
@@ -38,9 +39,16 @@ namespace ReadyPlayerMe.Loader
             {
                 throw new InvalidDataException($"Expected cast {typeof(string)}");
             }
-            context.Metadata = await Download(context.AvatarUri.MetadataUrl, token);
-            // context.SaveInProjectFolder is used to ensure that avatar is re-downloaded when using the Avatar Loader Window
-            context.Metadata.IsUpdated = context.SaveInProjectFolder || IsUpdated(context.Metadata, context.AvatarUri, context.AvatarCachingEnabled);
+            if (Application.internetReachability == NetworkReachability.NotReachable)
+            {
+                context.Metadata = LoadFromFile(context.AvatarUri.LocalMetadataPath);
+            }
+            else
+            {
+                context.Metadata = await Download(context.AvatarUri.MetadataUrl, token);
+                // context.SaveInProjectFolder is used to ensure that avatar is re-downloaded when using the Avatar Loader Window
+                context.Metadata.IsUpdated = context.SaveInProjectFolder || IsUpdated(context.Metadata, context.AvatarUri, context.AvatarCachingEnabled);
+            }
 
             if (context.Metadata.IsUpdated)
             {


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.monday.com/boards/2563815861/pulses/TICKETID)

No ticket ID, external PR

## Description

- The avatar download process used to fail when no internet was available
- Now MetadataDownloader and AvatarDownloader check for an internet connection
- The behavior is only changed when there is no internet available

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Updated

-   Instead of timing out when there is no internet connection, the MetadataDownloader and AvatarDownloader now attempt to load from the file cache first instead.

## How to Test

- Cut off the internet connection.
- Have avatars in the file cache location.

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



