### PR TITLE
fix: force create new settings asset before build

### DIFF
--- a/Editor/BuildPostProcessor.cs
+++ b/Editor/BuildPostProcessor.cs
@@ -11,6 +11,11 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
         [PostProcessBuild(1)]
         public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
         {
+            // create asset if it has been deleted
+            if (CoreSettingsHandler.CoreSettings == null)
+            {
+                ReadyPlayerMe.Core.Editor.EditorAssetGenerator.CreateSettingsAssets();
+            }
             AppData appData = ApplicationData.GetData();
             AnalyticsEditorLogger.EventLogger.LogBuildApplication(appData.BuildTarget, PlayerSettings.productName, !Debug.isDebugBuild);
         }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.monday.com/boards/2563815861/pulses/TICKETID)

## Description

-   there is currently a number of issues caused if the core settings asset is not there (or has been deleted) this update fixed that and forces it to be created if it does not exist.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes


#### Updated

-   BuildPostProcessor now creates core settings if missing

<!-- Testability -->

## How to Test

-   BuildPostProcessor now creates core settings if it is missing

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



