### PR TITLE
[4026640904] Caching issue due to time zone

### DIFF
--- a/Runtime/Data/AvatarContext.cs
+++ b/Runtime/Data/AvatarContext.cs
@@ -17,5 +17,6 @@ namespace ReadyPlayerMe.AvatarLoader
         public AvatarRenderSettings RenderSettings;
         public bool SaveInProjectFolder;
         public string Url;
+        public bool IsUpdated;
     }
 }

--- a/Runtime/Data/AvatarMetadata.cs
+++ b/Runtime/Data/AvatarMetadata.cs
@@ -9,7 +9,6 @@ namespace ReadyPlayerMe.AvatarLoader
     {
         public BodyType BodyType;
         public OutfitGender OutfitGender;
-        public DateTime LastModified;
-        public bool IsUpdated;
+        public DateTime UpdatedAt;
     }
 }

--- a/Runtime/Operations/AvatarDownloader.cs
+++ b/Runtime/Operations/AvatarDownloader.cs
@@ -53,7 +53,7 @@ namespace ReadyPlayerMe.AvatarLoader
                 throw new InvalidDataException($"Expected cast {typeof(string)} instead got ");
             }
 
-            if ((!context.Metadata.IsUpdated || Application.internetReachability == NetworkReachability.NotReachable)
+            if ((!context.IsUpdated || Application.internetReachability == NetworkReachability.NotReachable)
                     && File.Exists(context.AvatarUri.LocalModelPath))
             {
                 SDKLogger.Log(TAG, "Loading model from cache.");
@@ -61,7 +61,7 @@ namespace ReadyPlayerMe.AvatarLoader
                 return context;
             }
 
-            if (context.Metadata.IsUpdated)
+            if (context.IsUpdated)
             {
                 AvatarCache.ClearAvatar(context.AvatarUri.Guid, context.SaveInProjectFolder);
             }

--- a/Runtime/Operations/MetadataDownloader.cs
+++ b/Runtime/Operations/MetadataDownloader.cs
@@ -48,8 +48,8 @@ namespace ReadyPlayerMe.Loader
             else
             {
                 context.Metadata = await Download(context.AvatarUri.MetadataUrl, token);
-                context.IsUpdated = IsUpdated(context.Metadata, context.AvatarUri, context.AvatarCachingEnabled);
-                if (context.SaveInProjectFolder || context.IsUpdated)
+                context.IsUpdated = context.SaveInProjectFolder || IsUpdated(context.Metadata, context.AvatarUri, context.AvatarCachingEnabled);
+                if (context.IsUpdated)
                 {
                     SaveToFile(context.Metadata, context.AvatarUri.Guid, context.AvatarUri.LocalMetadataPath, context.SaveInProjectFolder);
                 }

--- a/Runtime/Operations/MetadataDownloader.cs
+++ b/Runtime/Operations/MetadataDownloader.cs
@@ -48,14 +48,13 @@ namespace ReadyPlayerMe.Loader
             else
             {
                 context.Metadata = await Download(context.AvatarUri.MetadataUrl, token);
-                // context.SaveInProjectFolder is used to ensure that avatar is re-downloaded when using the Avatar Loader Window
-                context.Metadata.IsUpdated = context.SaveInProjectFolder || IsUpdated(context.Metadata, context.AvatarUri, context.AvatarCachingEnabled);
+                context.IsUpdated = IsUpdated(context.Metadata, context.AvatarUri, context.AvatarCachingEnabled);
+                if (context.SaveInProjectFolder || context.IsUpdated)
+                {
+                    SaveToFile(context.Metadata, context.AvatarUri.Guid, context.AvatarUri.LocalMetadataPath, context.SaveInProjectFolder);
+                }
             }
 
-            if (context.Metadata.IsUpdated)
-            {
-                SaveToFile(context.Metadata, context.AvatarUri.Guid, context.AvatarUri.LocalMetadataPath, context.SaveInProjectFolder);
-            }
             return context;
         }
 

--- a/Tests/Editor/MetadataDownloadTests.cs
+++ b/Tests/Editor/MetadataDownloadTests.cs
@@ -103,7 +103,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
                 return;
             }
 
-            Assert.AreNotEqual(default(DateTime), metadata.LastModified);
+            Assert.AreNotEqual(default(DateTime), metadata.UpdatedAt);
         }
 
         [Test]


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [4026640904](https://ready-player-me.monday.com/boards/2563815861/pulses/4026640904)

## Description

- Newtonsoft fails to parse the time format, and due to this issue, the `LastModified` header has been used for checking the avatar update time. This apparently causes issues when avatars are cached due to time zone differences.
- Since Metadata has been supporting updatedAt field for a while, we might no longer need to use LastModified header. 
- More about the issue: https://github.com/readyplayerme/rpm-unity-sdk-avatar-loader/issues/54

<!-- Fill the section below with Added, Updated, and Removed information. -->
<!-- If there is no item under one of the lists remove its title. -->

## Changes

#### Added
-   `DateFormatString` setting added to `ParseResponse` method where metadata text is parsed.

#### Removed
- IsUpdated field is removed from `AvatarMetadata` and moved into `AvatarContext`.
- Header missing exception is removed.

<!-- Testability -->

## How to Test
- Reinstall the package from https://github.com/readyplayerme/rpm-unity-sdk-avatar-loader.git#feature/caching-update
- Create and load an avatar through a script on a device that is in a different time zone.

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.




