### PR TITLE
[4026673868] Add avatar loaded events

### DIFF
--- a/Editor/UI/EditorWindows/AvatarLoaderEditorWindow.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditorWindow.cs
@@ -1,9 +1,9 @@
-using UnityEngine;
-using UnityEditor;
 using ReadyPlayerMe.Core;
-using ReadyPlayerMe.Core.Editor;
 using ReadyPlayerMe.Core.Analytics;
+using ReadyPlayerMe.Core.Editor;
 using ReadyPlayerMe.Loader;
+using UnityEditor;
+using UnityEngine;
 
 namespace ReadyPlayerMe.AvatarLoader.Editor
 {
@@ -168,6 +168,8 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
             }, true);
         }
 
+        private double startTime;
+
         private void DrawLoadAvatarButton()
         {
             Horizontal(() =>
@@ -175,6 +177,7 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
                 GUI.enabled = isValidUrlShortcode && !string.IsNullOrEmpty(url);
                 if (GUILayout.Button("Load Avatar into the Current Scene", avatarButtonStyle))
                 {
+                    startTime = EditorApplication.timeSinceStartup;
                     AnalyticsEditorLogger.EventLogger.LogLoadAvatarFromDialog(url, useEyeAnimations, useVoiceToAnim);
                     if (avatarLoaderSettings == null)
                     {
@@ -206,8 +209,7 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
         {
             if (e.GetType() == typeof(MetadataDownloader))
             {
-                Debug.Log(e.GetType());
-                AnalyticsEditorLogger.EventLogger.LogMetadataDownloaded();
+                AnalyticsEditorLogger.EventLogger.LogMetadataDownloaded(EditorApplication.timeSinceStartup - startTime);
             }
         }
 
@@ -226,7 +228,7 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
             EditorUtilities.CreatePrefab(avatar, $"{DirectoryUtility.GetRelativeProjectPath(avatar.name)}/{avatar.name}.prefab");
 
             Selection.activeObject = args.Avatar;
-            AnalyticsEditorLogger.EventLogger.LogAvatarLoaded();
+            AnalyticsEditorLogger.EventLogger.LogAvatarLoaded(EditorApplication.timeSinceStartup - startTime);
         }
     }
 }

--- a/Editor/UI/EditorWindows/AvatarLoaderEditorWindow.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditorWindow.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using ReadyPlayerMe.Core;
 using ReadyPlayerMe.Core.Editor;
 using ReadyPlayerMe.Core.Analytics;
+using ReadyPlayerMe.Loader;
 
 namespace ReadyPlayerMe.AvatarLoader.Editor
 {
@@ -183,6 +184,7 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
                     avatarLoader.SaveInProjectFolder = true;
                     avatarLoader.OnFailed += Failed;
                     avatarLoader.OnCompleted += Completed;
+                    avatarLoader.OperationCompleted += OnOperationCompleted;
                     if (avatarLoaderSettings != null)
                     {
                         avatarLoader.AvatarConfig = avatarLoaderSettings.AvatarConfig;
@@ -200,6 +202,15 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
             }, true);
         }
 
+        private void OnOperationCompleted(object sender, IOperation<AvatarContext> e)
+        {
+            if (e.GetType() == typeof(MetadataDownloader))
+            {
+                Debug.Log(e.GetType());
+                AnalyticsEditorLogger.EventLogger.LogMetadataDownloaded();
+            }
+        }
+
         private void Failed(object sender, FailureEventArgs args)
         {
             Debug.LogError($"{args.Type} - {args.Message}");
@@ -215,6 +226,7 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
             EditorUtilities.CreatePrefab(avatar, $"{DirectoryUtility.GetRelativeProjectPath(avatar.name)}/{avatar.name}.prefab");
 
             Selection.activeObject = args.Avatar;
+            AnalyticsEditorLogger.EventLogger.LogAvatarLoaded();
         }
     }
 }

--- a/Runtime/AvatarObjectLoader.cs
+++ b/Runtime/AvatarObjectLoader.cs
@@ -60,6 +60,8 @@ namespace ReadyPlayerMe.AvatarLoader
         /// Called upon avatar loader success.
         public event EventHandler<CompletionEventArgs> OnCompleted;
 
+        public event EventHandler<IOperation<AvatarContext>> OperationCompleted;
+
         /// <summary>
         /// Load avatar from a URL.
         /// </summary>
@@ -103,6 +105,7 @@ namespace ReadyPlayerMe.AvatarLoader
             });
             executor.ProgressChanged += ProgressChanged;
             executor.Timeout = Timeout;
+            executor.OperationCompleted += op => OperationCompleted?.Invoke(this, op);
 
             ProgressChanged(0, nameof(AvatarObjectLoader));
             try


### PR DESCRIPTION
## [4026673868](https://ready-player-me.monday.com/boards/2563815861/pulses/4026673868)

## Changes

#### Added

- Call for metadata downloaded and avatar loaded analytics event

## How to Test

- Should be tested with `feature/operation-completed-event` branch of core module
- Try loading avatar from editor window and observe analytics event on amplitude
- Note: analytics should be enabled

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



