### PR TITLE
[SDK-98] Fix url for multiple avatar render sample

### DIFF
--- a/Samples~/MultipleAvatarRender/MultipleAvatarRenderExample.unity
+++ b/Samples~/MultipleAvatarRender/MultipleAvatarRenderExample.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748171, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Samples~/MultipleAvatarRender/MultipleAvatarRenderExample.unity
+++ b/Samples~/MultipleAvatarRender/MultipleAvatarRenderExample.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748171, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1549,12 +1549,12 @@ MonoBehaviour:
     avatarRenderScene: 2
     image: {fileID: 37516423}
     imageLoaded: 0
-  - url: https://d1a370nemizbjq.cloudfront.net/93321c9f-60da-4020-ac35-00f92d81da92.glb
-    avatarRenderScene: 0
+  - url: https://models.readyplayer.me/63ff40ce9dc8b8dcb3b575af.glb
+    avatarRenderScene: 1
     image: {fileID: 1835301669}
     imageLoaded: 0
-  - url: https://d1a370nemizbjq.cloudfront.net/93321c9f-60da-4020-ac35-00f92d81da92.glb
-    avatarRenderScene: 1
+  - url: https://models.readyplayer.me/63da539e72f63b7131df0782.glb
+    avatarRenderScene: 3
     image: {fileID: 1491639854}
     imageLoaded: 0
   loadingPanel: {fileID: 466104546}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
       "displayName": "MultipleQualityAvatarLoading",
       "description": "Loads the same avatar multiple times with different quality settings.",
       "path": "Samples~/MultipleQualityAvatarLoading"
+    },
+    {
+      "displayName": "MultipleAvatarRender",
+      "description": "Loads the multiple avatar render with different settings.",
+      "path": "Samples~/MultipleAvatarRender"
     }
   ]
 }


### PR DESCRIPTION
## [SDK-98](https://ready-player-me.atlassian.net/browse/SDK-98)

## Description

-   Briefly describe what this change will do

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Added

- Multiple avatar render sample to package.json

#### Updated

- Cloudfront url for multiple avatar render sample

## How to Test

- Run Multiple avatar render sample

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-98]: https://ready-player-me.atlassian.net/browse/SDK-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ