### PR TITLE
Fix that trims URL to prevent copy paste with white space

### DIFF
--- a/Runtime/Operations/UrlProcessor.cs
+++ b/Runtime/Operations/UrlProcessor.cs
@@ -58,7 +58,7 @@ namespace ReadyPlayerMe.AvatarLoader
         public async Task<AvatarUri> ProcessUrl(string url, string paramsHash, CancellationToken token = new CancellationToken())
         {
             var fractions = url.Split('?'); // separate parameters
-            url = fractions[0];
+            url = fractions[0].Trim(); // trim to remove any white spaces
             var avatarApiParameters = fractions.Length > 1 ? $"?{fractions[1]}" : "";
             if (url.ToLower().EndsWith(GLB_EXTENSION))
             {


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.monday.com/boards/2563815861/pulses/TICKETID)

## Description

-   There is currently an issue that if you copy a URL but include a space and beginning or end it can cause failure to download the avatar or metadata this change fixes that

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Fixed

-   an issue where white space wasn't being trimmed from url

<!-- Testability -->

## How to Test

-   you can test by intentionally copy/pasting or entering in avatar URL with a space at the beginning or end of the URL, and see if it still loads

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



