### PR TITLE
[SDK-46] MeshOpt Compression Support in AvatarConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2023.04.14
+
+### Added
+- Mesh Optimization compression support.
+
 ## [1.1.0] - 2023.03.21
 
 ### Added

--- a/Runtime/Data/AvatarConfig.cs
+++ b/Runtime/Data/AvatarConfig.cs
@@ -29,8 +29,10 @@ namespace ReadyPlayerMe.AvatarLoader
         };
         [Tooltip("Only works for halfbody avatars. If enabled, avatars will load with hand meshes included.")]
         public bool UseHands;
-        [Tooltip("Enable if you want to use Draco compression for mesh optimization.")]
+        [Tooltip("Enable if you want to use Draco compression. More effective on complex meshes.")]
         public bool UseDracoCompression;
+        [Tooltip("Enable if you want to use Mesh Otimization compression. More effective on meshes with morph targets.")]
+        public bool UseMeshOptCompression;
         [HideInInspector]
         public List<string> MorphTargets = new List<string>();
     }

--- a/Runtime/Utils/AvatarAPIParameters.cs
+++ b/Runtime/Utils/AvatarAPIParameters.cs
@@ -11,6 +11,7 @@ namespace ReadyPlayerMe.AvatarLoader
         public const string MORPH_TARGETS = "morphTargets";
         public const string USE_HANDS = "useHands";
         public const string USE_DRACO = "useDracoMeshCompression";
+        public const string USE_MESHOPT = "useMeshOptCompression";
         public const string RENDER_BLEND_SHAPES = "blendShapes";
         public const string RENDER_SCENE = "scene";
     }

--- a/Runtime/Utils/AvatarConfigProcessor.cs
+++ b/Runtime/Utils/AvatarConfigProcessor.cs
@@ -36,6 +36,7 @@ namespace ReadyPlayerMe.AvatarLoader
             }
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_HANDS, GetBoolStringValue(avatarConfig.UseHands));
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_DRACO, GetBoolStringValue(avatarConfig.UseDracoCompression));
+            queryBuilder.AddKeyValue(AvatarAPIParameters.USE_MESHOPT, GetBoolStringValue(avatarConfig.UseMeshOptCompression));
             
             return queryBuilder.GetQuery;
         }

--- a/Tests/Editor/AvatarAPITests.cs
+++ b/Tests/Editor/AvatarAPITests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -46,6 +47,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             avatarConfig.UseHands = false;
             avatarConfig.TextureChannel = GetAllTextureChannels();
             avatarConfig.UseDracoCompression = false;
+            avatarConfig.UseMeshOptCompression = false;
             var morphTargets = new List<string>();
             morphTargets.Add("none");
             avatarConfig.MorphTargets = morphTargets;
@@ -62,6 +64,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             avatarConfig.UseHands = false;
             avatarConfig.TextureChannel = GetAllTextureChannels();
             avatarConfig.UseDracoCompression = false;
+            avatarConfig.UseMeshOptCompression = false;
             var morphTargets = new List<string>();
             morphTargets.Add("Oculus Visemes");
             avatarConfig.MorphTargets = morphTargets;
@@ -78,6 +81,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             avatarConfig.UseHands = false;
             avatarConfig.TextureChannel = GetAllTextureChannels();
             avatarConfig.UseDracoCompression = false;
+            avatarConfig.UseMeshOptCompression = false;
             var morphTargets = new List<string>();
             morphTargets.Add("Oculus Visemes");
             avatarConfig.MorphTargets = morphTargets;
@@ -207,6 +211,24 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             Assert.AreEqual(FailureType.None, failureType);
             Assert.IsNotNull(avatar);
             Assert.AreEqual(AVATAR_CONFIG_BLEND_SHAPE_COUNT_MED, blendShapeCount);
+        }
+        
+        [Test] 
+        public async Task AvatarLoader_Avatar_API_MeshOptCompression()
+        {
+            var avatarConfig = ScriptableObject.CreateInstance<AvatarConfig>();
+            avatarConfig.MeshLod = MeshLod.Low;
+            avatarConfig.TextureAtlas = TextureAtlas.Low;
+            avatarConfig.MorphTargets = new List<string> { "none" };
+            avatarConfig.TextureChannel = new [] { TextureChannel.BaseColor };
+
+            var downloader = new AvatarDownloader();
+            var normalBytes = await downloader.DownloadIntoMemory(AVATAR_API_AVATAR_URL, avatarConfig);
+            
+            avatarConfig.UseMeshOptCompression = true;
+            var meshOptBytes = await downloader.DownloadIntoMemory(AVATAR_API_AVATAR_URL, avatarConfig);
+            
+            Assert.Less(meshOptBytes.Length, normalBytes.Length);
         }
     }
 }


### PR DESCRIPTION
## Description

- Support for useMeshOptCompression parameter support in avatar URL added.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Added

- useMeshOptCompression option in AvatarConfig

<!-- Testability -->

## How to Test

- Create an avatar using meshopt parameter in the avatar config
- Compare file size to same avatar without meshopt and check visual integrity of the avatar

<!-- Update your progress with the task here -->

## Checklist

-   [x] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.



