### PR TITLE
[SDK-113] Add api for async avatar loading

### DIFF
--- a/Runtime/AvatarObjectLoader.cs
+++ b/Runtime/AvatarObjectLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using ReadyPlayerMe.Core;
 using ReadyPlayerMe.Loader;
 using UnityEngine;
@@ -72,6 +73,37 @@ namespace ReadyPlayerMe.AvatarLoader
             SDKLogger.Log(TAG, $"Started loading avatar with config {(AvatarConfig ? AvatarConfig.name : "None")} from URL {url}");
             avatarUrl = url;
             Load(url);
+        }
+        
+        /// <summary>
+        /// Load avatar asynchronously from a URL and return the result as eventArgs.
+        /// </summary>
+        /// <param name="url">The URL to the avatars .glb file.</param>
+        public async Task<EventArgs> LoadAvatarAsync(string url)
+        {
+            EventArgs eventArgs = null;
+            var isCompleted = false;
+            OnCompleted += (sender, args) =>
+            {
+                eventArgs = args;
+                isCompleted = true;
+            };
+            OnFailed += (sender, args) =>
+            {
+                eventArgs = args;
+                isCompleted = true;
+            };
+            
+            startTime = Time.timeSinceLevelLoad;
+            SDKLogger.Log(TAG, $"Started loading avatar with config {(AvatarConfig ? AvatarConfig.name : "None")} from URL {url}");
+            avatarUrl = url;
+            Load(url);
+            
+            while (!isCompleted)
+            {
+                await Task.Yield();
+            }
+            return eventArgs;
         }
 
         /// <summary>

--- a/Tests/Editor/AvatarConfigProcessorTests.cs
+++ b/Tests/Editor/AvatarConfigProcessorTests.cs
@@ -10,7 +10,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
         private const string TEXTURECHANNELS_EXPECTED_NONE = "&textureChannels=none";
         private const string MORPHTARGETS_EXPECTED_DEFAULT = "mouthOpen,mouthSmile";
         private const string MORPHTARGETS_EXPECTED_NONE = "none";
-        private const string AVATAR_QUERY_PARAMS_ACTUAL = "?pose=A&meshLod=0&textureAtlas=none&textureSizeLimit=1024&textureChannels=baseColor,normal,metallicRoughness,emissive,occlusion&useHands=false&useDracoMeshCompression=false";
+        private const string AVATAR_QUERY_PARAMS_ACTUAL = "?pose=A&meshLod=0&textureAtlas=none&textureSizeLimit=1024&textureChannels=baseColor,normal,metallicRoughness,emissive,occlusion&useHands=false&useDracoMeshCompression=false&useMeshOptCompression=false";
         private readonly string[] morphTargetsDefault = { "mouthOpen", "mouthSmile" };
         private readonly string[] morphTargetsNone = { "none" };
         private readonly TextureChannel[] textureChannelsAll =

--- a/Tests/Editor/AvatarLoaderTests.cs
+++ b/Tests/Editor/AvatarLoaderTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -36,6 +37,30 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             Assert.AreEqual(FailureType.None, failureType);
             Assert.IsNotNull(avatar);
             Assert.IsNotNull(avatar.GetComponent<AvatarData>());
+        }
+
+        [Test]
+        public async Task AvatarLoader_Complete_Load_Async()
+        {
+            var loader = new AvatarObjectLoader();
+            var args = await loader.LoadAvatarAsync(TestAvatarData.DefaultAvatarUri.ModelUrl);
+
+            Assert.True(args != null);
+
+            if (args.GetType() == typeof(FailureEventArgs))
+            {
+                Assert.Fail(((FailureEventArgs) args).Type.ToString());
+            }
+            else if (args.GetType() == typeof(CompletionEventArgs))
+            {
+                var completedEventArgs = (CompletionEventArgs) args;
+                Assert.AreEqual(TestAvatarData.DefaultAvatarUri.ModelUrl, completedEventArgs.Url);
+                Assert.IsNotNull(completedEventArgs.Avatar);
+            }
+            else
+            {
+                Assert.Fail("Unknown event args type");
+            }
         }
 
         [UnityTest]

--- a/Tests/Editor/QueryBuilderTests.cs
+++ b/Tests/Editor/QueryBuilderTests.cs
@@ -4,7 +4,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
 {
     public class QueryBuilderTests
     {
-        private const string ATLAS_AND_MORPHS = "?textureAtlas=512&morphTargets=mouthSmile,ARKit";
+        private const string ATLAS_AND_MORPHS = "?textureAtlas=1024&morphTargets=mouthSmile,ARKit";
         private const string QUALITY_LOW_MESH_LOD = "?quality=low&meshLod=0";
         
         private readonly string[] morphTargetsDefault = { "mouthSmile", "ARKit" };


### PR DESCRIPTION
## [SDK-113](https://ready-player-me.atlassian.net/browse/SDK-113)

## Changes

#### Added

-  API for avatar loading async

#### Updated

- Fix tests with avatar config parameters failing 

<!-- Testability -->

## How to Test

-  Run the tests

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-113]: https://ready-player-me.atlassian.net/browse/SDK-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ