### PR TITLE
[SDK-158] Add defer agent docs link button

### DIFF
--- a/Editor/UI/Helpers/AvatarConfigFields.cs
+++ b/Editor/UI/Helpers/AvatarConfigFields.cs
@@ -28,6 +28,7 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
         private const string GLTF_DEFER_AGENT = "GLTF defer agent";
         private const string AVATAR_CACHING_TOGGLE_LABEL = "Avatar caching enabled";
         private const string AVATAR_CONFIG_DOCS_LINK = "https://docs.readyplayer.me/ready-player-me/integration-guides/unity/optimize/avatar-configuration";
+        private const string DEFER_AGENT_DOCS_LINK = "https://docs.readyplayer.me/ready-player-me/integration-guides/unity/optimize/defer-agents";
 
         private readonly GUILayoutOption objectFieldWidth = GUILayout.Width(280);
 
@@ -78,7 +79,8 @@ namespace ReadyPlayerMe.AvatarLoader.Editor
             {
                 GUILayout.Space(15);
                 EditorGUILayout.LabelField(new GUIContent(GLTF_DEFER_AGENT, DEFER_AGENT_TOOLTIP), GUILayout.Width(100));
-                GUILayout.Space(51);
+                DocumentationButton.Draw(DEFER_AGENT_DOCS_LINK);
+                GUILayout.Space(30);
 
                 gltfDeferAgent = EditorGUILayout.ObjectField(gltfDeferAgent, typeof(GLTFDeferAgent), false, objectFieldWidth) as GLTFDeferAgent;
                 if (avatarLoaderSettings != null && avatarLoaderSettings.GLTFDeferAgent != gltfDeferAgent)


### PR DESCRIPTION
## [SDK-158](https://ready-player-me.atlassian.net/browse/SDK-158)

## Changes

#### Added

- Defer agent docs link button in Settings

## How to Test

-  Open settings and click help button next to gltf defer agent label

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-158]: https://ready-player-me.atlassian.net/browse/SDK-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ