### PR TITLE
[SDK-184] chore: fix path

### DIFF
--- a/Runtime/Operations/UrlProcessor.cs
+++ b/Runtime/Operations/UrlProcessor.cs
@@ -91,7 +91,7 @@ namespace ReadyPlayerMe.AvatarLoader
                 avatarUri.ImageUrl = url.Replace(".glb", ".png");
                 avatarUri.LocalModelPath = $"{fileName}{GLB_EXTENSION}";
                 avatarUri.MetadataUrl = GetMetadataUrl(url);
-                fileName = $"{DirectoryUtility.GetAvatarSaveDirectory(avatarUri.Guid, SaveInProjectFolder)}{avatarUri.Guid}";
+                fileName = $"{DirectoryUtility.GetAvatarSaveDirectory(avatarUri.Guid, SaveInProjectFolder)}/{avatarUri.Guid}";
                 avatarUri.LocalMetadataPath = $"{fileName}{JSON_EXTENSION}";
 
                 SDKLogger.Log(TAG, PROCESSING_COMPLETED);

--- a/Tests/Editor/AvatarUriProcessTests.cs
+++ b/Tests/Editor/AvatarUriProcessTests.cs
@@ -54,7 +54,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             Assert.AreEqual(expectedUri.ModelUrl, avatarUri.ModelUrl);
             Assert.AreEqual(expectedUri.MetadataUrl, avatarUri.MetadataUrl);
             Assert.AreEqual($"{dir}/{avatarUri.Guid}{TestUtils.GLB_SUFFIX}", avatarUri.LocalModelPath);
-            Assert.AreEqual($"{jsonDir}{avatarUri.Guid}{TestUtils.JSON_SUFFIX}", avatarUri.LocalMetadataPath);
+            Assert.AreEqual($"{jsonDir}/{avatarUri.Guid}{TestUtils.JSON_SUFFIX}", avatarUri.LocalMetadataPath);
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             Assert.AreEqual(expectedShortcodeUri.ModelUrl, avatarUri.ModelUrl);
             Assert.AreEqual(expectedShortcodeUri.MetadataUrl, avatarUri.MetadataUrl);
             Assert.AreEqual($"{dir}/{avatarUri.Guid}{TestUtils.GLB_SUFFIX}", avatarUri.LocalModelPath);
-            Assert.AreEqual($"{jsonDir}{avatarUri.Guid}{TestUtils.JSON_SUFFIX}", avatarUri.LocalMetadataPath);
+            Assert.AreEqual($"{jsonDir}/{avatarUri.Guid}{TestUtils.JSON_SUFFIX}", avatarUri.LocalMetadataPath);
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
             Assert.AreEqual(expectedShortcodeUri.ModelUrl, avatarUri.ModelUrl);
             Assert.AreEqual(expectedShortcodeUri.MetadataUrl, avatarUri.MetadataUrl);
             Assert.AreEqual($"{dir}/{avatarUri.Guid}{TestUtils.GLB_SUFFIX}", avatarUri.LocalModelPath);
-            Assert.AreEqual($"{jsonDir}{avatarUri.Guid}{TestUtils.JSON_SUFFIX}", avatarUri.LocalMetadataPath);
+            Assert.AreEqual($"{jsonDir}/{avatarUri.Guid}{TestUtils.JSON_SUFFIX}", avatarUri.LocalMetadataPath);
         }
     }
 }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-184](https://ready-player-me.atlassian.net/browse/SDK-184)

<!-- Replace the branch with the dependency, if no dependency is required than set this to develop -->
## Dependencies
```Package
Core: develop
```

## Description

-   Fixes an issue that avatars loaded in editor have the metadata json saved in root Avatars folder with name [GUID+GUID].json instead of inside the Avatars/GUID/ folder 

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Updated

-   Url processor and tests, added missing slash to path

<!-- Testability -->

## How to Test

-  PLEASE TEST this for runtime, in editor and in builds to ensure this does not introduce any new bugs

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->


[SDK-184]: https://ready-player-me.atlassian.net/browse/SDK-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ