### PR TITLE
[SDK-189] Use Invariant Culture on Float to String Conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [x.x.x] - UNRELEASED
+
+### Updated
+- AvatarRenderSettings updated to use InvariantCulture with ToString to avoid issues.
+
 ## [1.3.0] - 2023.05.29
 
 ### Added

--- a/Runtime/Data/AvatarRenderSettings.cs
+++ b/Runtime/Data/AvatarRenderSettings.cs
@@ -1,5 +1,5 @@
+using System.Globalization;
 using System.Collections.Generic;
-using System.Text;
 
 namespace ReadyPlayerMe.AvatarLoader
 {
@@ -22,7 +22,9 @@ namespace ReadyPlayerMe.AvatarLoader
             {
                 foreach (var blendShapeMesh in BlendShapeMeshes)
                 {
-                    queryBuilder.AddKeyValue($"{AvatarAPIParameters.RENDER_BLEND_SHAPES}[{blendShapeMesh}][{blendShape.Key}]", blendShape.Value.ToString());
+                    string key = $"{AvatarAPIParameters.RENDER_BLEND_SHAPES}[{blendShapeMesh}][{blendShape.Key}]";
+                    string value = blendShape.Value.ToString(CultureInfo.InvariantCulture);
+                    queryBuilder.AddKeyValue(key, value);
                 }
             }
             

--- a/Tests/Editor/AvatarRenderLoaderTests.cs
+++ b/Tests/Editor/AvatarRenderLoaderTests.cs
@@ -14,7 +14,7 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
         private const string RENDER_BLENDSHAPE = "mouthSmile";
         private const string RENDER_WRONG_BLENDSHAPE = "wrong_blendshape";
         private const float BLENDSHAPE_VALUE = 0.5f;
-
+        private const string RENDER_STRING = "?scene=fullbody-portrait-v1-transparent&blendShapes[Wolf3D_Head][mouthSmile]=0.5";
 
         [UnityTest]
         public IEnumerator RenderLoader_Load()
@@ -119,6 +119,22 @@ namespace ReadyPlayerMe.AvatarLoader.Tests
 
             Assert.AreEqual(FailureType.None, failureType);
             Assert.IsNotNull(renderTexture);
+        }
+        
+        // create a render string test
+        [Test]
+        public void RenderLoader_CreateRenderString()
+        {
+            var renderSettings = new AvatarRenderSettings
+            {
+                Scene = RENDER_SCENE,
+                BlendShapeMeshes = renderBlendshapeMeshes,
+                BlendShapes = new Dictionary<string, float> { { RENDER_BLENDSHAPE, BLENDSHAPE_VALUE } }
+            };
+
+            var renderString = renderSettings.GetParametersAsString();
+
+            Assert.AreEqual(RENDER_STRING, renderString);
         }
     }
 }


### PR DESCRIPTION
- Use ToString with invariant culture to make sure float to string conversions do not create comma and dot confusion.

<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-189](https://ready-player-me.atlassian.net/browse/SDK-189)

<!-- Replace the branch with the dependency, if no dependency is required than set this to develop -->
## Dependencies
```Package
Core: develop
```

## Description

- Depending on users local CuntureInfo float to string conversions might cause issue due to a float such as `0.7` might turn into string as `0,7` with a comma.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Updated

- AvatarRenderSettings updated to use InvariantCulture with ToString to avoid issues.

<!-- Update your progress with the task here -->

## Checklist

-   [x] Tests written or updated for the changes.
-   [x] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->


[SDK-189]: https://ready-player-me.atlassian.net/browse/SDK-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ